### PR TITLE
refactor: mejora la generacion de manifiestos para multiples manifiestos

### DIFF
--- a/src/manifest_generator.py
+++ b/src/manifest_generator.py
@@ -171,7 +171,8 @@ def main():
         manifiesto = generar_manifiesto(contenido_template, values)
         if not manifiesto:
             return 1
-        print(f"\n{'*'*6} Manifiesto generado: {os.path.basename(template_path)} {'*'*6}")
+        print(f"\n{'*'*6} Manifiesto generado:")
+        print(f"{os.path.basename(template_path)} {'*'*6}")
         print(manifiesto)
 
         # Validar manifiesto antes de mostrar o guardar
@@ -184,7 +185,8 @@ def main():
             return 1
         # Guardar en archivo solo si se especifica el output
         if args.output:
-            nombre_archivo = os.path.splitext(os.path.basename(template_path))[0]
+            nombre_base = os.path.basename(template_path)
+            nombre_archivo = os.path.splitext(nombre_base)[0]
             ruta_output = os.path.join(args.output, nombre_archivo)
             guardar_manifiesto(manifiesto, ruta_output)
         print(f"{'='*50}")

--- a/src/manifest_generator.py
+++ b/src/manifest_generator.py
@@ -184,7 +184,9 @@ def main():
             return 1
         # Guardar en archivo solo si se especifica el output
         if args.output:
-            guardar_manifiesto(manifiesto, args.output)
+            nombre_archivo = os.path.splitext(os.path.basename(template_path))[0]
+            ruta_output = os.path.join(args.output, nombre_archivo)
+            guardar_manifiesto(manifiesto, ruta_output)
         print(f"{'='*50}")
     return 0
 

--- a/src/manifest_generator.py
+++ b/src/manifest_generator.py
@@ -142,7 +142,8 @@ def main():
         description="Generador de manifiestos de kubernetes"
     )
     parser.add_argument(
-        '--template', '-t',
+        '--templates', '-t',
+        nargs='+',
         required=True,
         help='Ruta al archivo de template (.template)'
     )
@@ -162,27 +163,29 @@ def main():
         return 1
     if not validar_values(values):
         return 1
-    contenido_template = cargar_template(args.template)
-    if not contenido_template:
-        return 1
-    print(f"{'='*50}")
-    manifiesto = generar_manifiesto(contenido_template, values)
-    if not manifiesto:
-        return 1
-    print(f"{'*'*6} Manifiesto generado {'*'*6}")
-    print(manifiesto)
-    # Validar manifiesto antes de mostrar o guardar
-    nombre_template = os.path.basename(args.template)
-    if not validar_manifiesto_k8s(manifiesto, nombre_template):
-        print(
-            "\nEl manifiesto generado NO es válido para Kubernetes. "
-            "No se guardará el archivo."
-        )
-        return 1
-    # Guardar en archivo solo si se especifica el output
-    if args.output:
-        guardar_manifiesto(manifiesto, args.output)
-    print(f"{'='*50}")
+    for template_path in args.templates:
+        contenido_template = cargar_template(template_path)
+        if not contenido_template:
+            return 1
+        print(f"{'='*50}")
+        manifiesto = generar_manifiesto(contenido_template, values)
+        if not manifiesto:
+            return 1
+        print(f"\n{'*'*6} Manifiesto generado: {os.path.basename(template_path)} {'*'*6}")
+        print(manifiesto)
+
+        # Validar manifiesto antes de mostrar o guardar
+        nombre_template = os.path.basename(template_path)
+        if not validar_manifiesto_k8s(manifiesto, nombre_template):
+            print(
+                "\nEl manifiesto generado NO es válido para Kubernetes. "
+                "No se guardará el archivo."
+            )
+            return 1
+        # Guardar en archivo solo si se especifica el output
+        if args.output:
+            guardar_manifiesto(manifiesto, args.output)
+        print(f"{'='*50}")
     return 0
 
 

--- a/tests/test_multiples_manifiestos.py
+++ b/tests/test_multiples_manifiestos.py
@@ -52,7 +52,10 @@ def test_generar_deployment_manifiesto():
     """
     Test que se genere correctamente un manifiesto de deployment
     """
-    resultado = manifest_generator.generar_manifiesto(deployment_template, values)
+    resultado = manifest_generator.generar_manifiesto(
+        deployment_template,
+        values
+    )
 
     assert resultado is not None
     assert "test-app-deployment" in resultado
@@ -65,7 +68,10 @@ def test_generar_service_manifiesto():
     """
     Test que se genere correctamente un manifiesto de service
     """
-    resultado = manifest_generator.generar_manifiesto(service_template, values)
+    resultado = manifest_generator.generar_manifiesto(
+        service_template,
+        values
+    )
 
     assert resultado is not None
     assert "test-app-service" in resultado
@@ -79,8 +85,14 @@ def test_generar_multiples_manifiestos_mismo_values():
     Test generar multiples manifiestos con los mismos values
     """
     # Generar ambos manifiestos
-    deployment = manifest_generator.generar_manifiesto(deployment_template, values)
-    service = manifest_generator.generar_manifiesto(service_template, values)
+    deployment = manifest_generator.generar_manifiesto(
+        deployment_template,
+        values
+    )
+    service = manifest_generator.generar_manifiesto(
+        service_template,
+        values
+    )
 
     # Verificar que ambos se generaron
     assert deployment is not None
@@ -118,7 +130,7 @@ def test_template_inexistente():
     """
     Test manejo de archivo template que no existe
     """
-    resultado = manifest_generator.cargar_template('/archivo/que/no/existe.template')
+    resultado = manifest_generator.cargar_template('no_existe.template')
     assert resultado is None
 
 
@@ -126,5 +138,5 @@ def test_values_inexistente():
     """
     Test manejo de archivo values que no existe
     """
-    resultado = manifest_generator.cargar_values('/archivo/que/no/existe.yaml')
+    resultado = manifest_generator.cargar_values('no_existe.yaml')
     assert resultado is None

--- a/tests/test_multiples_manifiestos.py
+++ b/tests/test_multiples_manifiestos.py
@@ -1,0 +1,130 @@
+import src.manifest_generator as manifest_generator
+
+
+# Datos de prueba
+values = {
+    "app_name": "test-app",
+    "protocol": "TCP",
+    "image": "nginx:latest",
+    "replicas": 2,
+    "container_port": 80,
+    "service_port": 8080
+}
+
+deployment_template = """
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ app_name }}-deployment
+spec:
+  replicas: {{ replicas }}
+  selector:
+    matchLabels:
+      app: {{ app_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ app_name }}
+    spec:
+      containers:
+      - name: {{ app_name }}
+        image: {{ image }}
+        ports:
+        - containerPort: {{ container_port }}
+"""
+
+service_template = """
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ app_name }}-service
+spec:
+  selector:
+    app: {{ app_name }}
+  ports:
+  - protocol: {{ protocol }}
+    port: {{ service_port }}
+    targetPort: {{ container_port }}
+"""
+
+
+def test_generar_deployment_manifiesto():
+    """
+    Test que se genere correctamente un manifiesto de deployment
+    """
+    resultado = manifest_generator.generar_manifiesto(deployment_template, values)
+
+    assert resultado is not None
+    assert "test-app-deployment" in resultado
+    assert "replicas: 2" in resultado
+    assert "nginx:latest" in resultado
+    assert "containerPort: 80" in resultado
+
+
+def test_generar_service_manifiesto():
+    """
+    Test que se genere correctamente un manifiesto de service
+    """
+    resultado = manifest_generator.generar_manifiesto(service_template, values)
+
+    assert resultado is not None
+    assert "test-app-service" in resultado
+    assert "TCP" in resultado
+    assert "port: 8080" in resultado
+    assert "targetPort: 80" in resultado
+
+
+def test_generar_multiples_manifiestos_mismo_values():
+    """
+    Test generar multiples manifiestos con los mismos values
+    """
+    # Generar ambos manifiestos
+    deployment = manifest_generator.generar_manifiesto(deployment_template, values)
+    service = manifest_generator.generar_manifiesto(service_template, values)
+
+    # Verificar que ambos se generaron
+    assert deployment is not None
+    assert "test-app-deployment" in deployment
+    assert "replicas: 2" in deployment
+    assert "nginx:latest" in deployment
+    assert "containerPort: 80" in deployment
+
+    assert service is not None
+    assert "test-app-service" in service
+    assert "TCP" in service
+    assert "port: 8080" in service
+    assert "targetPort: 80" in service
+
+
+def test_validacion_values_true():
+    """
+    Test de la validacion de values funcione y devuelva true
+    """
+    # Values validos deben pasar
+    assert manifest_generator.validar_values(values) is True
+
+
+def test_validacion_values_false():
+    """
+    Test de la validacion de values funcione y devuelva false
+    """
+    # Values invalidos deben fallar
+    values_malos = values.copy()
+    values_malos['replicas'] = 'invalido'  # string en lugar de int
+    assert manifest_generator.validar_values(values_malos) is False
+
+
+def test_template_inexistente():
+    """
+    Test manejo de archivo template que no existe
+    """
+    resultado = manifest_generator.cargar_template('/archivo/que/no/existe.template')
+    assert resultado is None
+
+
+def test_values_inexistente():
+    """
+    Test manejo de archivo values que no existe
+    """
+    resultado = manifest_generator.cargar_values('/archivo/que/no/existe.yaml')
+    assert resultado is None


### PR DESCRIPTION
## Descripcion
Se mejoro la generacion de manifiestos para que se pueda generar multiples manifiestos apartir de un solo archivo values.yaml

## Cambios realizados
- Mejora manifest_generator.py para generar multiples manifiestos de un solo values.yaml
- Agrega tests para validar la mejora de la funcionalidad de generacion de manifiestos